### PR TITLE
Add empty div to cart line items for Clyde to attach a prompt to.

### DIFF
--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -40,6 +40,7 @@
             <div class="cart-item-giftwrap">
               {{> components/cart/gift-wrap-item}}
             </div>
+            <div class="clyde-cart-attach-point" data-item-id="{{id}}"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Add a parent element to append Clyde cart prompts to, with line item ID data. Additional changes can be made to do conditional rendering on this new div, but as it will only be populated for line items with contracts available, it can be left to render for all and stay empty for non-eligible items.

Note: Made a new branch off of 1.20.22 and switched the target branch for this PR to 1.20.22, per @grantmx 