### PR TITLE
Update _blog.scss

### DIFF
--- a/assets/scss/templates/_blog.scss
+++ b/assets/scss/templates/_blog.scss
@@ -3,6 +3,16 @@
     - extends brands page properties
 */
 
+.container, .top-bar .container, .top-bar .product-tabs, .main-content .container{
+    max-width: $standard-width;
+}
+
+.container, .product-tabs, .account-wrapper{
+    padding: 0 2vw;
+}
+
+
+
 .blog{
     @extend %span-1-1;
     @extend %span;


### PR DESCRIPTION
The current blog .scss does not have a container class. Because of this, using the container class in the blog breaks the entire page. This change adds the container class to the blog. I added the classes from the container that I found in production.