### PR TITLE
Update _landing.scss

### DIFF
--- a/assets/scss/templates/_landing.scss
+++ b/assets/scss/templates/_landing.scss
@@ -32,6 +32,7 @@
 
     &__hero{
         margin-bottom: 20px;
+        margin-top: 30px;
         max-height: 500px;
         height: auto;
         overflow: hidden;


### PR DESCRIPTION
Added margin-top of 30px to __hero so that hero images are not so close to the h1 and author of the blog pages.