### PR TITLE
Added landing__row--reverse

### DIFF
--- a/assets/scss/templates/_landing.scss
+++ b/assets/scss/templates/_landing.scss
@@ -334,6 +334,10 @@
             flex-wrap: wrap;
             justify-content: center;
         }
+        
+        &--reverse{
+            flex-direction: row-reverse;
+        }
 
         &--noFlex{
             display: block;


### PR DESCRIPTION
This will reverse the flex-direction of the row to allow for an S pattern on the desktop and an ideal image/text pattern on mobile.