### PR TITLE
Updates for June page releases

### DIFF
--- a/assets/scss/components/_buttons.scss
+++ b/assets/scss/components/_buttons.scss
@@ -7,7 +7,7 @@
     border-width: 1px;
     border-style: solid;
     font-size: 1.1rem;
-    text-transform: capitalize !important;    
+    //text-transform: capitalize !important;
     font-weight: 500;
     @extend %button-rounded;
     text-decoration: none !important;
@@ -28,13 +28,27 @@
     }
 
     &--long {
-        padding: 6px 50px;
+        padding: 17px 50px;
     }
 
     &.button-wide{
         @media screen and (max-width: $screen-sm){
             padding-left: 20px !important;
             padding-right: 20px !important;
+        }
+    }
+
+    &--left{
+        float: left;
+    }
+
+    &--right{
+        float: right;
+    }
+
+    &--center--sm{
+        @media only screen and (max-width: $screen-sm){
+            float: none !important;
         }
     }
 }
@@ -89,11 +103,9 @@
     }
 
     &--white {
-        background-color:#F0F0F0;
-        border-color: #F0F0F0;
-        color: #353E5D;
-        padding: 15px 70px;
-        font-size: 1.1rem;
+        background-color:#fff;
+        border-color: #4D5060;
+        color: #4D5060;
     }
 
     &--darkGray {
@@ -110,27 +122,8 @@
 
     &--transparent {
         background-color: transparent;
-        border: 2px solid #353E5D;
-        color: #353E5D;
-        font-size: 35px;
-        padding: 15px 78px;
-        margin-top: 10%;
-
-        @media only screen and (max-width: $screen-lg) {
-            font-size: 24px;
-            padding: 10px 50px;
-        }
-
-        @media only screen and (max-width: $screen-md) {
-            font-size: 20px;
-            padding: 10px 40px;
-        }
-
-        @media only screen and (max-width: $screen-sm) {
-            margin-top: 130px;
-            font-size: 24px;
-            padding: 10px 60px;            
-        }
+        border: 2px solid #fff;
+        color: #fff;
     }
 }
 

--- a/assets/scss/components/_generics.scss
+++ b/assets/scss/components/_generics.scss
@@ -1,3 +1,4 @@
+
 // global scroll bar
 %scrolling-inner{
     overflow-y: auto;
@@ -360,7 +361,9 @@
     background-color: $bg-brown;
 }
 
-.bg-img {
+
+//Banners
+.hp-bannerImg-1 {
     background-image: url(https://authenteak.s3.us-east-2.amazonaws.com/WS00035_042321_MayHomepageWireframe_Images/JPG/WS00035_TradeBanner_Full_Desktop.jpg);
     background-repeat: no-repeat;
     background-size: cover;
@@ -372,17 +375,41 @@
     }
 }
 
-.bg-heroImg {
-    background-image: url(https://authenteak.s3.us-east-2.amazonaws.com/WS00010_AprilHomepage_Images/WEBP/WS00010_HeroImageDesktop.webp);
+.hp-bannerImg-2 {
+    background-image: url(https://authenteak.s3.us-east-2.amazonaws.com/WS00070_060121_JuneHomepageWireframe_images/JPG/WS00070_FirePitsBanner_Desktop.jpg);
     background-repeat: no-repeat;
+    background-size: cover;
 
     @media only screen and (max-width: $screen-sm) {
-        background-image: url(https://authenteak.s3.us-east-2.amazonaws.com/WS00010_AprilHomepage_Images/WEBP/WS00010_HeroImageMobile.webp);
-        z-index: 10;
+        background-image: url(https://authenteak.s3.us-east-2.amazonaws.com/WS00070_060121_JuneHomepageWireframe_images/JPG/WS00070_FirePitsBanner_Mobile.jpg);
+        height: 280px;
 
     }
 }
 
+.hestan-bannerImg{
+    background-image: url(https://authenteak.s3.us-east-2.amazonaws.com/WS00078_052121_GrillingRebatePages_Images/Hestan/JPG/WS00078_HestanWarranty_Desktop.jpg);
+    background-repeat: no-repeat;
+    background-size: cover;
+
+    @media only screen and (max-width: $screen-sm) {
+        background-image: url(https://authenteak.s3.us-east-2.amazonaws.com/WS00078_052121_GrillingRebatePages_Images/Hestan/JPG/WS00078_HestanWarranty_Mobile.jpg);
+        height: 280px;
+
+    }
+}
+
+.alfresco-bannerImg{
+    background-image: url(https://authenteak.s3.us-east-2.amazonaws.com/WS00078_052121_GrillingRebatePages_Images/Alfresco/JPG/WS00078_AlfrescoWarranty_Desktop.jpg);
+    background-repeat: no-repeat;
+    background-size: cover;
+
+    @media only screen and (max-width: $screen-sm) {
+        background-image: url(https://authenteak.s3.us-east-2.amazonaws.com/WS00078_052121_GrillingRebatePages_Images/Alfresco/JPG/WS00078_AlfrescoWarranty_Mobile.jpg);
+        height: 280px;
+
+    }
+}
 
 
 // text
@@ -484,6 +511,10 @@
 
 }
 
+.topStroke{
+    background: linear-gradient(#fff 0%, #fff 10%, #DFE9EF 10%, #DFE9EF 100%);
+}
+
 //Hover
 
 .hoverContainer {
@@ -508,6 +539,15 @@
 }
 
 //Carousel
+
+.col-spacing{
+    height: 375px;
+
+    @media only screen and (max-width:$screen-sm){
+        height: 150px;
+    }
+}
+
 .carousel-img-card{
     position: absolute;
     width: 60%;
@@ -549,12 +589,20 @@
     transform: translatex(-40%) scale(.8);
     opacity: .3;
     z-index: 0;
+
+    @media only screen and (max-width: $screen-sm){
+        opacity: .1;
+    }
   }
   
   #item-1:checked ~ .carousel-cards #img-2, #item-2:checked ~ .carousel-cards #img-3, #item-3:checked ~ .carousel-cards #img-1 {
     transform: translatex(40%) scale(.8);
     opacity: .3;
     z-index: 0;
+
+    @media only screen and (max-width: $screen-sm){
+        opacity: .1;
+    }
   }
   
   #item-1:checked ~ .carousel-cards #img-1, #item-2:checked ~ .carousel-cards #img-2, #item-3:checked ~ .carousel-cards #img-3 {

--- a/assets/scss/layout/_default.scss
+++ b/assets/scss/layout/_default.scss
@@ -30,6 +30,9 @@ html{
 
 .site-canvas{
   padding: 0 !important;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   // margin-top: 163px;
   // transition: margin-top 0.25s ease;
 

--- a/assets/scss/templates/_landing.scss
+++ b/assets/scss/templates/_landing.scss
@@ -7,6 +7,8 @@
     @extend %span-1-1;
     @extend %span;
     @extend .no-pad;
+    max-width: 1920px;
+    width: 100%;
 
     &--topSpace{
         margin-top: 0;

--- a/templates/pages/custom/page/_template_a.html
+++ b/templates/pages/custom/page/_template_a.html
@@ -52,34 +52,21 @@
     </div>
     <!--Bar under Hero End-->
 
-   <!--POVL Banner Start-->
-    <a class="landing__linkFull" href="https://authenteak.com/featured-offers/shop-all-featured-offers/#/filter:brand:POVL$2520Outdoor">
-        <div class="landing__row landing__row--wrapCenter pad stroke" style="background-color: #fff;">
-            <div class="landing__col-1-4--lg landing__col-1-3" >
-                <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00053_042821_POVLSaleHPBlock_Images/SVG/WS00053_SummerReadySaleLockup.svg" class="landing__figImg lazy-image pad" alt="Summer-Ready Sale">
-                <div style="width: 40%; margin: auto;">
-                    <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00053_042821_POVLSaleHPBlock_Images/PNG/WS00053_POVLLogoDesktop.png" alt="POVL Outdoor" class="landing__figImg lazy-image">
-                </div>
-                
-                <h2 class="landing__header pad-top bold text--navy no-margin" style="font-size: 45px; letter-spacing: 3px;">
-                    TAKE 10% OFF
-                </h2>
-                <p class="landing__p text--navy no-margin" style="font-size: 20px;">
-                    <strong>Our exclusive POVL OUTDOOR collection</strong>
-                </p>
-                <p class="landing__p text--navy"">Outdoor luxury you won't find anywhere else</p>
-                <div class="button text--navy" style="background-color: transparent; font-size: 25px; padding: 15px 40px; white-space: nowrap;">Shop the sale</div>
-            </div>
-            <div class="landing__col-2-4--lg landing__col-2-3">
-                <picture class="landing__figImg">
-                    <source media="(min-width: 770px)" srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00053_042821_POVLSaleHPBlock_Images/WEBP/WS00053_Image_Desktop.webp" type="image/webp">
-                    <source media="(min-width: 770px)" srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00053_042821_POVLSaleHPBlock_Images/JPG/WS00053_Image_Desktop.jpg" type="image/jpeg">
-                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00053_042821_POVLSaleHPBlock_Images/WEBP/WS00053_Image_Desktop.webp" alt="Three daybeds in front of a pool." class="landing__figImg landing__figImg--default">
+   <!--Memorial Banner Start-->
+    <a href="https://authenteak.com/featured-offers/" class="landing__linkFull" title="Shop Memorial Day Sale">
+        <div class="landing__row landing__row--wrapCenter" style="background-color: #023A60;">
+            <div class="landing__col-1-1">
+                <picture class="landing__heroImg">
+                    <source media="(max-width: 699px)" srcset="https://authenteak.s3.us-east-2.amazonaws.com/2021-Memorial-Day-Campaign/Banners-PaidAds-Social/Webps/WS00056_MemorialDay_HP_MobileBanner.webp" type="image/webp">
+                    <source media="(max-width: 699px)" srcset="https://authenteak.s3.us-east-2.amazonaws.com/2021-Memorial-Day-Campaign/Banners-PaidAds-Social/Jpegs/WS00056_MemorialDay_HP_MobileBanner.jpg" type="image/jpeg">
+                    <source media="(min-width: 700px)" srcset="https://authenteak.s3.us-east-2.amazonaws.com/2021-Memorial-Day-Campaign/Banners-PaidAds-Social/Webps/WS00056_MemorialDay_HP_DesktopBanner.webp" type="image/webp">
+                    <source media="(min-width: 700px)" srcset="https://authenteak.s3.us-east-2.amazonaws.com/2021-Memorial-Day-Campaign/Banners-PaidAds-Social/Jpegs/WS00056_MemorialDay_HP_DesktopBanner.jpg" type="image/jpeg">
+                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/2021-Memorial-Day-Campaign/Banners-PaidAds-Social/Webps/WS00056_MemorialDay_HP_DesktopBanner.webp" alt="Save 10% on select outdoor furniture and planters through May 31st!" class="landing__heroImg landing__heroImg--default no-margin">
                 </picture>
             </div>
         </div>
     </a>    
-    <!--POVL Banner End-->
+    <!--Memorial Banner End-->
 
     <!--Best Selling Dining Sets-->
     <div class="landing__row landing__row--wrapCenter margin-top">

--- a/templates/pages/custom/page/_template_b.html
+++ b/templates/pages/custom/page/_template_b.html
@@ -1,363 +1,590 @@
 {{#partial "page"}}
-<div class="landing">
-    <div class="landing__row landing__row--wrapCenter">
-        <div class="landing__container landing__container--center landing__row--wrapCenter margin-top margin-left no-margin-sm">
-            <div class="landing__col-1-2--md landing__col-1-1 no-margin-sm margin-top no-pad">
+
+<div class="landing">    
+
+    <h2 class="landing__header landing__header--3 c upper pad-top text--charcoal bold">
+        Everything you need to know before buying a
+    </h2>
+    <h2 class="landing__header landing__header--1 c upper serif" style="color: #4D5060;">
+        Fire pit
+    </h2>
+    <div class="landing__row landing__row--wrapCenter" style="margin: 0 0 60px;">
+        <div class="landing__container--center landing__row--wrapCenter" style="max-width: 1035px;">
+            <div class="landing__col-1-1">
+                <p class="landing__p text--charcoal">
+                    The right outdoor fire pit has the power to transform a backyard or commercial space into a year-round gathering destination—from s’mores in the winter to spritzes in the summer.<br><br>Fire pits can be a long-lasting addition to your outdoor space, so it’s important to choose one that’s the right size, shape, style and functionality. Here is everything you need to know about <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/" title="Shop All Fire Pits">high-quality fire pits</a> before purchasing.
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <!--Color Banner-->
+    <div class="landing__row landing__row--wrapCenter " style="background-color: #4D5060; padding: 60px 0;">
+        <div class="landing__container--center landing__row--wrapCenter" style="max-width: 1035px;">
+            <div class="landing__col-1-1">
+                <h2 class="landing__header landing__header--2 c text--white upper">
+                    Fire Pit Styles
+                </h2>
+                <hr style="border: 1px solid #fff; height: .01rem; width: 100%; max-width: 560px; margin: 30px auto;">
+                <p class="landing__p c text--white">
+                    Outdoor fire pits come in a variety of styles—each of which fits into a unique aesthetic and function. When choosing the right style for you, consider how you plan to use your outdoor space and what kind of look you’re after. Here are some of the most popular styles:
+                </p>
+            </div>
+        </div>        
+    </div>
+
+    <!--S Pattern-->
+    <div class="landing__row landing__row--wrapCenter text--charcoal" >
+        <div class="landing__container--center landing__row--reverse landing__row--wrapCenter" style="max-width: 1500px; margin: 30px 0;">
+            <div class="landing__col-1-2--lg landing__col-1-1">
                 <picture class="landing__figImg">
-                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS00002_TradePage_HeroImage.webp" type="image/webp">
-                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/JPG/WS00002_TradePage_HeroImage.jpg" type="image/jpeg">
-                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS00002_TradePage_HeroImage.webp" alt="Various chaise loungers with white cushions under large white square umbrellas." type="image/webp" class="landing__figImg landing__figImg--default lazy-image" >
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_FireBowl_Desktop.webp" type="image/webp">
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_FireBowl_Desktop.jpg" type="image/jpeg">
+                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_FireBowl_Desktop.webp" alt="A white fire bowl on a wooden deck with burning fire rocks." class="landing__figImg landing__figImg--default lazy-image">
                 </picture>
             </div>
             <div class="landing__col-1-2--lg landing__col-1-1">
-                <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WS00002_TradePage_Logo.svg" alt="AuthenTEAK PRO Trade + Hospitality" class="landing__figImg lazy-image pad-bottom" style="width: 75%;">
-                <p class="landing__p">
-                    Dedicated project support, no ancillary fees and<br>exclusive trade pricing—all in one membership.
-                </p>
-                <div class="landing__col-1-1 no-pad">
-                    <a href="" class="button" style="color: #fff;">Apply to our trade program</a>
-                </div>
-                <div class="landing__col-1-1 no-pad" style="margin-top: 10px;">
-                    <a href="" class="button" style="background-color: #F0F0F0; color: #2E303B; border: 1px solid #F0F0F0;">&nbsp; &nbsp; Get a hospitality quote &nbsp; &nbsp;</a>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="landing__row landing__row--wrapCenter bg--grey">
-        <div class="landing__col-1-1 margin-top">
-            <h2 class="landing__header landing__header--3 upper no-margin" style="letter-spacing: 3.2px; line-height: 37px;">
-                Learn more about AuthenTEAK Professional Services
-            </h2>
-        </div>
-    </div>
-
-    <div class="landing__row landing__row--wrapCenter margin-top-lg">
-        <div class="landing__container landing__container--center landing__row--wrapCenter margin-left-lg no-margin-sm">
-            <div class="landing__col-1-2--md landing__col-1-1">
-                <picture class="landing__figImg">
-                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_TradePage_TradePBenefitsImage.webp" type="image/webp">
-                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/JPG/WS0002_TradePage_TradePBenefitsImage.jpg" type="image/jpeg">
-                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_TradePage_TradePBenefitsImage.webp" alt="A rooftop sitting area with various couches and chairs." type="image/webp" class="landing__figImg landing__figImg--default lazy-image" >
-                </picture>
-            </div>
-            <div class="landing__col-1-2" style="max-width: 470px; margin: auto;">
-                <h2 class="landing__header landing__header--2 l upper" style="letter-spacing: 3.2px;" >
-                    Exclusive Trade<br>
-                    & Commercial Benefits
+                <h2 class="landing__header landing__header--2 upper l">
+                    Fire Bowls
                 </h2>
-                <p class="landing__p l" style="font-size: 20px;">
-                    • Trade and volume pricing<br>
-                    • B2B website access for online trade ordering<br>
-                    • No minimums or ancillary fees<br>
-                    • Tax exempt purchasing (if qualified)
+                <p class="landing__p l">
+                    &bull; The most popular fire pits.
                 </p>
-            </div>
-        </div>
-    </div>
-    <div class="landing__row landing__row--wrapCenter landing__row--reverse">
-        <div class="landing__container landing__container--center landing__row--wrapCenter landing__row--reverse">
-            <div class="landing__col-1-2--md landing__col-1-1">
-                <picture class="landing__figImg">
-                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_TradePage_ProjectSupportImage.webp" type="image/webp">
-                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/JPG/WS0002_TradePage_ProjectSupportImage.jpg" type="image/jpeg">
-                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_TradePage_ProjectSupportImage.webp" alt="A hand sorting through various fabrics of different colors and patterns." type="image/webp" class="landing__figImg landing__figImg--default lazy-image" >
-                </picture>
-            </div>
-            <div class="landing__col-1-2" style="max-width: 470px; margin: auto;">
-                <h2 class="landing__header landing__header--2 l" style="letter-spacing: 3.2px;">
-                    PROJECT SUPPORT
-                </h2>
-                <p class="landing__p l" style="font-size: 20px;">
-                    • In depth knowledge of outdoor products, materials & applications<br>
-                    • Procurement services<br>
-                    • Order management from product selection<br>
-                    to project completion<br>
-                    • Space planning and design services<br>
-                    • Finish Samples<br>
-                    • Warehousing and logistics
+                <p class="landing__p l">
+                    &bull; Can sit directly on the ground, be elevated with legs or even placed on a pedestal.
                 </p>
-            </div>
-        </div>
-    </div>
-
-    <div class="landing__row landing__row--wrapCenter margin-bottom-lg">
-        <div class="landing__container landing__container--center landing__row--wrapCenter margin-left-lg no-margin-sm">
-            <div class="landing__col-1-2--md landing__col-1-1">
-                <picture class="landing__figImg">
-                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_TradePage_DeliveryImage.webp" type="image/webp">
-                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/JPG/WS0002_TradePage_DeliveryImage.jpg" type="image/jpeg">
-                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_TradePage_DeliveryImage.webp" alt="A pool with various chaise loungers and umbrellas." type="image/webp" class="landing__figImg landing__figImg--default lazy-image" >
-                </picture>
-            </div>
-            <div class="landing__col-1-2" style="max-width: 470px; margin: auto;">
-                <h2 class="landing__header landing__header--2 l" style="letter-spacing: 3.2px;">
-                    DELIVERY SERVICES
-                </h2>
-                <p class="landing__p l" style="font-size: 20px;">
-                    • Nationwide shipping and delivery<br>
-                    • White Glove delivery and assembly<br>
-                    • Multi-brand coordination<br>
-                    • Pick-up (Atlanta only)<br>
-                    • Installation services (local and regional)
+                <p class="landing__p l">
+                    &bull; Available in a multitude of materials, most commonly low-maintenance metals or durable cast concrete.
                 </p>
-            </div>
-        </div>
-    </div>
-
-    <div class="landing__row landing__row--wrapCenter" style="background-color: #353E5D;">
-        <div class="landing__container landing__container--center">
-            <div class="landing__col-1-1">
-                <h2 class="landing__header landing__header--2 c upper text--white no-margin pad-top" style="letter-spacing: 3.2px;">
-                    After Sales Services
-                </h2>
-            </div>
-            <div class="landing__col-1-3--lg landing__col-1-2 landing__col--flexCenter">
-                <span>
-                    <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/PNG/WS00002_MaintenanceIcon.png" style="width: 25%; vertical-align: middle;" alt="" class="landing__figImg lazy-image l">
-                    <a style="font-size: 24px; line-height: 28px; color: #fff; text-align: left; vertical-align: middle; padding: 10px 0 0 10px;">
-                    Maintenance tips<br>and products
+                <p class="landing__p l">
+                    &bull; While many fire bowls have a thin edge, some have a wide rim that allows for additional functionality.
+                </p>
+                <p class="landing__p l bg--gray bold" style="padding: 10px; margin: 20px 0; max-width: 640px;">
+                    
+                    Style tip: Not all fire bowls are round. You’ll find square, octagon, and rectangle fire pits, as well as ones with shapely edges.
+                    
+                </p>
+                <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_shape:Round" title="Shop Fire Bowls"  class="button button-primary--white button--left button--center--sm">
+                    Shop fire bowls
                 </a>
-                </span>
             </div>
-            <div class="landing__col-1-3--lg landing__col-1-2 landing__col--flexCenter">
-                <span>
-                    <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/PNG/WS00002_WarantyIcon.png" style="width: 25%; vertical-align: middle;" alt="" class="landing__figImg lazy-image l">
-                    <a style="font-size: 24px; line-height: 28px; color: #fff; text-align: left; vertical-align: middle; padding-left: 10px; padding: 10px 0 0 10px;">
-                        Warranty support
+        </div>
+    </div>
+
+    <div class="landing__row landing__row--wrapCenter text--charcoal" >
+        <div class="landing__container--center landing__row--wrapCenter" style="max-width: 1500px; margin: 30px 0;">
+            <div class="landing__col-1-2--lg landing__col-1-1">
+                <picture class="landing__figImg">
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_FireTable_Desktop.webp" type="image/webp">
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_FireTable_Desktop.jpg" type="image/jpeg">
+                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_FireTable_Desktop.webp" alt="Two concrete fire tables side by side in front of blue sofas and metal chairs." class="landing__figImg landing__figImg--default lazy-image">
+                </picture>
+            </div>
+            <div class="landing__col-1-2--lg landing__col-1-1">
+                <h2 class="landing__header landing__header--2 upper l">
+                    Fire Tables
+                </h2>
+                <p class="landing__p l">
+                    &bull; Function like a fire pit and outdoor coffee table, with a controlled fire in the center.
+                </p>
+                <p class="landing__p l">
+                    &bull; Typically fueled by Natural Gas (NG) or Liquid Propane (LP) to allow safe, close interaction.
+                </p>
+                <p class="landing__p l">
+                    &bull; Often available with an optional lid that covers the burner, creating additional surface area.
+                </p>                
+                <p class="landing__p l bg--gray bold" style="padding: 10px; margin: 20px 0; max-width: 640px;">
+                    
+                    Style tip: It’s most common to see a fire table in front of a deep-seating group of furniture.
+                    
+                </p>
+                <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/gas-fire-pits-fire-tables/#/filter:custom_shape:Rectangular" title="Shop Fire Tables"  class="button button-primary--white button--left button--center--sm">
+                    Shop fire tables
                 </a>
-                </span>
             </div>
-            <div class="landing__col-1-3--lg landing__col-1-2 landing__col--flexCenter">
-                <span>
-                    <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/PNG/WS00002_PhoneIcon.png" style="width: 21%; vertical-align: middle;" alt="" class="landing__figImg lazy-image l">
-                    <a style="font-size: 24px; line-height: 28px; color: #fff; text-align: left; vertical-align: middle; padding-left: 14px; padding: 10px 0 0 14px;">
-                        Accessible<br>customer service
+        </div>
+
+        <div class="landing__row landing__row--wrapCenter text--charcoal" >
+            <div class="landing__container--center landing__row--reverse landing__row--wrapCenter" style="max-width: 1500px; margin: 30px 0;">
+                <div class="landing__col-1-2--lg landing__col-1-1">
+                    <picture class="landing__figImg">
+                        <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_FireUrn_Desktop.webp" type="image/webp">
+                        <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_FireUrn_Desktop.jpg" type="image/jpeg">
+                            <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_FireUrn_Desktop.webp" alt="A fire urn with burning fire rocks in front of a pond." class="landing__figImg landing__figImg--default lazy-image">
+                    </picture>
+                </div>
+                <div class="landing__col-1-2--lg landing__col-1-1">
+                    <h2 class="landing__header landing__header--2 upper l">
+                        Fire Urns
+                    </h2>
+                    <p class="landing__p l">
+                        &bull; Elongated versions of fire bowls.
+                    </p>
+                    <p class="landing__p l">
+                        &bull; Inspired by Roman decorative elements.
+                    </p>
+                    <p class="landing__p l">
+                        &bull; Most include the ability to conceal a standard 20-pound LP tank.
+                    </p>                    
+                    <p class="landing__p l bg--gray bold" style="padding: 10px; margin: 20px 0; max-width: 640px;">
+                        
+                        Style tip: Fire urn styles range from casual to contemporary, depending on the design elements.
+                        
+                    </p>
+                    <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_category:Fire$2520Urns" title="Shop Fire Urns"  class="button button-primary--white button--left button--center--sm">
+                        Shop fire urns
                     </a>
-                </span>
-            </div>
-        </div>
-    </div>
-    <div class="landing__row landing__row--wrapCenter pad-top margin-bottom-lg" style="background-image: url(https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/JPG/WS00002_BrandsBanner_Desktop.jpg); letter-spacing: 3.2px;">
-        <div class="landing__col-1-1">
-            <h2 class="landing__header landing__header--2 c upper">
-                Featured Commercial Brands
-            </h2>
-        </div>
-        <div class="landing__container landing__contianer--center">
-            <div class="landing__col-1-4 landing__col--flexCenter" >
-                <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/PNG/WS00002_Tuuci.png" alt="" class="landing__figImg lazy-image">
-            </div>
-            <div class="landing__col-1-4 landing__col--flexCenter" >
-                <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/PNG/WS00002_caneline.png" alt="" class="landing__figImg lazy-image">
-            </div>
-            <div class="landing__col-1-4 landing__col--flexCenter" >
-                <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/PNG/WS00002_nardi.png" alt="" class="landing__figImg lazy-image">
-            </div>
-            <div class="landing__col-1-4 landing__col--flexCenter" >
-                <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/PNG/WS00002_kannoa.png" alt="" class="landing__figImg lazy-image">
-            </div>
-            <div class="landing__col-1-4 landing__col--flexCenter" >
-                <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/PNG/WS00002_Telescope.png" alt="" class="landing__figImg lazy-image">
-            </div>
-            <div class="landing__col-1-4 landing__col--flexCenter" >
-                <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/PNG/WS00002_Polywood.png" alt="" class="landing__figImg lazy-image">
+                </div>            
             </div>
         </div>
     </div>
 
-    <div class="landing__section margin-top" >
-        <div class="landing__row landing__row--wrapCenter no-margin-sm" >
+    <!--Color Banner-->
+    <div class="landing__row landing__row--wrapCenter " style="background-color: #4D5060; padding: 60px 0;">
+        <div class="landing__container--center landing__row--wrapCenter" style="max-width: 1035px;">
             <div class="landing__col-1-1">
-                <h2 class="landing__header landing__header--2 no-margin c" style="letter-spacing: 3.2px;">
-                    COMMERCIAL + HOSPITALITY PROJECTS
+                <h2 class="landing__header landing__header--2 c text--white upper">
+                    Fire Pit Fuel Types
                 </h2>
+                <hr style="border: 1px solid #fff; height: .01rem; width: 100%; max-width: 560px; margin: 30px auto;">
+                <p class="landing__p c text--white">
+                    If the sound and smell of a crackling fire is what you’re after, consider a wood-burning fire pit. Alternatively, if ease of use is a priority—or if your space is smaller or has an overhead roof — a propane or natural gas pit might be the best fit. Here’s a breakdown of each fuel type:
+                </p>
             </div>
-            <div class="landing__col-1-3">
+        </div>
+    </div>
+
+    <!--S Pattern-->
+    <div class="landing__row landing__row--wrapCenter text--charcoal" >
+        <div class="landing__container--center landing__row--wrapCenter" style="max-width: 1500px; margin: 30px 0;">
+            <div class="landing__col-1-2--lg landing__col-1-1">
                 <picture class="landing__figImg">
-                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS00002_AnsleyGolfImage.webp" type="image/webp">
-                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WS0002_TradePage_AnsleyGolfClub.jpg" type="image/jpeg">
-                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS00002_AnsleyGolfImage.webp" alt="The pool in Ansley Golf Club in Atlanta, GA." type="image/webp" class="landing__figImg landing__figImg--default lazy-image" style="border-radius: 10px; object-fit: cover;" >
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_WoodBurningFirePit_Desktop.webp" type="image/webp">
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_WoodBurningFirePit_Desktop.jpg" type="image/jpeg">
+                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_WoodBurningFirePit_Desktop.webp" alt="A large fire bowl with burning fire wood while a man sits near it." class="landing__figImg landing__figImg--default lazy-image">
                 </picture>
-              <p class="landing__titleCaption landing__titleCaption--small c">Ansley Golf Club / Atlanta, GA</p>
             </div>
-            <div class="landing__col-1-3">
-                <picture class="landing__figImg">
-                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_TradePage_PrintingHouseFitness.webp" type="image/webp">
-                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WS0002_TradePage_PrintingHouseFitness.jpg" type="image/jpeg">
-                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_TradePage_PrintingHouseFitness.webp" alt="Rooftop balcony at the Printing House Fitness in New York." type="image/webp" class="landing__figImg landing__figImg--default lazy-image" style=" border-radius: 10px; object-fit: cover;">
-                </picture>             
-              <p class="landing__titleCaption landing__titleCaption--small c">Printing House Fitness / New York</p>
+            <div class="landing__col-1-2--lg landing__col-1-1">
+                <h2 class="landing__header landing__header--2 upper l">
+                    Wood Burning Fire Pits
+                </h2>
+                <p class="landing__p l">
+                    &bull; Can produce much larger fires than other fuel types.
+                </p>
+                <p class="landing__p l">
+                    &bull; Require hands-on tending.
+                </p>
+                <p class="landing__p l">
+                    &bull; Not suitable for use on wood decks or other combustible locations.
+                </p>
+                <p class="landing__p l">
+                    &bull; Usually less expensive to purchase and to operate compared to non-wood burning fire pits.
+                </p>
+                <p class="landing__p l bg--gray bold" style="padding: 10px; margin: 20px 0; max-width: 640px;">
+                    
+                    Style tip: All wood burning fire pits should only be used in open spaces that are safe from other flammable materials.
+                    
+                </p>
+                <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_fuel:Wood$2520Burning" title="Shop Wood-Burning Fire Pits"  class="button button-primary--white button--left button--center--sm">
+                    Shop wood-burning fire pits
+                </a>
             </div>
-            <div class="landing__col-1-3">
+        </div>
+    </div>
+
+    <div class="landing__row landing__row--wrapCenter text--charcoal" >
+        <div class="landing__container--center landing__row--wrapCenter landing__row--reverse" style="max-width: 1500px; margin: 30px 0;">
+            <div class="landing__col-1-2--lg landing__col-1-1">
                 <picture class="landing__figImg">
-                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_TradePage_EdwardsInnSpa.webp" type="image/webp">
-                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WS0002_TradePage_EdwardsInnSpa.jpg" type="image/jpeg">
-                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_TradePage_EdwardsInnSpa.webp" alt="A blond woman walking in front of the chaise loungers in the Edwards Inn Spa in North Carolina." type="image/webp" class="landing__figImg landing__figImg--default lazy-image" style=" border-radius: 10px; object-fit: cover;">
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_LiquidPropaneFirePit_Desktop.webp" type="image/webp">
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_LiquidPropaneFirePit_Desktop.jpg" type="image/jpeg">
+                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_LiquidPropaneFirePit_Desktop.webp" alt="A liquid propane fire table in front of a sofa. A smaller image on the top right corner shows the fire table opened with the propane tank inside." class="landing__figImg landing__figImg--default lazy-image">
                 </picture>
-              <p class="landing__titleCaption landing__titleCaption--small c">Edwards Inn Spa / North Carolina</p>
             </div>
-            <!-- <div class="landing__col-1-1">
-                <div style="margin: 0; padding: 0; width: 100%; height: 100%; box-sizing: border-box;">
-                    <div style="display: flex; align-items: center; justify-content: center; padding: 30px 10px;">
-                        <div class="carousel-container">
-                            <input type="radio" name="slider" id="item-1" checked style="display: none;">
-                            <input type="radio" name="slider" id="item-2" style="display: none;">
-                            <input type="radio" name="slider" id="item-3" style="display: none;">
-                          <div class="carousel-cards">
-                            <label class="carousel-img-card" for="item-1" id="img-1">
-                                <picture class="landing__figImg">
-                                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS00002_AnsleyGolfImage.webp" type="image/webp">
-                                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WS0002_TradePage_AnsleyGolfClub.jpg" type="image/jpeg">
-                                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS00002_AnsleyGolfImage.webp" alt="The pool in Ansley Golf Club in Atlanta, GA." type="image/webp" class="landing__figImg landing__figImg--default lazy-image" style="border-radius: 10px; object-fit: cover;" >
-                                </picture>
-                              <p class="landing__titleCaption landing__titleCaption--small c">Ansley Golf Club / Atlanta, GA</p>
-                            </label>
+            <div class="landing__col-1-2--lg landing__col-1-1">
+                <h2 class="landing__header landing__header--2 upper l">
+                    Liquid Propane Fire Pits
+                </h2>
+                <p class="landing__p l">
+                    &bull; Ideal for those who don’t want to use wood, or who don’t have the ability to run a natural gas line.
+                </p>
+                <p class="landing__p l">
+                    &bull; Can be activated with the flip of a switch and allow more control over the flame.
+                </p>
+                <p class="landing__p l">
+                    &bull; Cost more to run than wood-fueled ones and require refilling.
+                </p>
+                <p class="landing__p l">
+                    &bull; Recommended use is with lava rock or colorful <a href="https://authenteak.com/outdoor-heating/fireglass-lava-rocks/" title="Shop Fire Glass and Lava Rocks">fire glass</a>.
+                </p>
+                <p class="landing__p l bg--gray bold" style="padding: 10px; margin: 20px 0; max-width: 640px;">
+                    
+                    Style tip: For a clean look, opt for a hidden tank option. Alternatively, consider a tank cover, which hides the tank and functions as a side table.
+                    
+                </p>
+                <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_fuel:Liquid$2520Propane" title="Shop Liquid Propane Fire Pits"  class="button button-primary--white button--left button--center--sm">
+                    Shop liquid propane fire pits
+                </a>
+            </div>
+        </div>
+
+        <div class="landing__row landing__row--wrapCenter text--charcoal" >
+            <div class="landing__container--center landing__row--wrapCenter" style="max-width: 1500px; margin: 30px 0;">
+                <div class="landing__col-1-2--lg landing__col-1-1">
+                    <picture class="landing__figImg">
+                        <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_NaturalGasFirePit_Desktop.webp" type="image/webp">
+                        <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_NaturalGasFirePit_Desktop.jpg" type="image/jpeg">
+                            <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_NaturalGasFirePit_Desktop.webp" alt="A man reading the newspaper in front of a square fire pit." class="landing__figImg landing__figImg--default lazy-image">
+                    </picture>
+                </div>
+                <div class="landing__col-1-2--lg landing__col-1-1">
+                    <h2 class="landing__header landing__header--2 upper l">
+                        Natural Gas Fire Pits
+                    </h2>
+                    <p class="landing__p l">
+                        &bull; Preferred choice for a permanently installed fire pit.
+                    </p>
+                    <p class="landing__p l">
+                        &bull; Ignited with the push of a button or the strike of a match. Options available for electronic ignition.
+                    </p>
+                    <p class="landing__p l">
+                        &bull; Require a natural gas line connected by a certified professional.
+                    </p>
+                    <p class="landing__p l">
+                        &bull; Recommended use is with lava rock or colorful <a href="https://authenteak.com/outdoor-heating/fireglass-lava-rocks/" title="Shop Fire Glass and Lava Rocks">fire glass</a>.
+                    </p>
+                    <p class="landing__p l">
+                        &bull; Generally less expensive to burn than liquid propane fire pits.
+                    </p>
+                    <p class="landing__p l bg--gray bold" style="padding: 10px; margin: 20px 0; max-width: 640px;">
+                        
+                        Style tip: Because there’s no propane tank, most natural gas fire pits are low to the ground, making them ideal for deep seating arrangements.
+                        
+                    </p>
+                    <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_fuel:Natural$2520Gas" title="Shop Natural Gas Fire Pits"  class="button button-primary--white button--left button--center--sm">
+                        Shop natural gas fire pits
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!--Color Banner-->
+    <div class="landing__row landing__row--wrapCenter " style="background-color: #4D5060; padding: 60px 0;">
+        <div class="landing__container--center landing__row--wrapCenter" style="max-width: 1150px;">
+            <div class="landing__col-1-1">
+                <h2 class="landing__header landing__header--2 c text--white upper">
+                    Fire Pit Materials
+                </h2>
+                <hr style="border: 1px solid #fff; height: .01rem; width: 100%; max-width: 560px; margin: 30px auto;">
+                <p class="landing__p c text--white">
+                    Material informs the longevity, maintenance, price, and look of your fire pit. Materials like concrete are durable and potentially heavy, ideal for permanent fixtures. Other materials like corten steel take on a beautiful, rustic-modern patina over time. It’s important to know the basics of each type before making a decision:
+                </p>
+            </div>
+        </div>        
+    </div>
     
-                            <label class="carousel-img-card" for="item-2" id="img-2">
-                                <picture class="landing__figImg">
-                                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_TradePage_PrintingHouseFitness.webp" type="image/webp">
-                                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WS0002_TradePage_PrintingHouseFitness.jpg" type="image/jpeg">
-                                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_TradePage_PrintingHouseFitness.webp" alt="Rooftop balcony at the Printing House Fitness in New York." type="image/webp" class="landing__figImg landing__figImg--default lazy-image" style=" border-radius: 10px; object-fit: cover;">
-                                </picture>             
-                              <p class="landing__titleCaption landing__titleCaption--small c">Printing House Fitness / New York</p>
-                            </label>
-    
-                            <label class="carousel-img-card" for="item-3" id="img-3">
-                                <picture class="landing__figImg">
-                                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_TradePage_EdwardsInnSpa.webp" type="image/webp">
-                                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WS0002_TradePage_EdwardsInnSpa.jpg" type="image/jpeg">
-                                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_TradePage_EdwardsInnSpa.webp" alt="A blond woman walking in front of the chaise loungers in the Edwards Inn Spa in North Carolina." type="image/webp" class="landing__figImg landing__figImg--default lazy-image" style=" border-radius: 10px; object-fit: cover;">
-                                </picture>
-                              <p class="landing__titleCaption landing__titleCaption--small c">Edwards Inn Spa / North Carolina</p>
-                            </label>
-                          </div>
-                        </div>
+    <!--S Pattern-->
+    <div class="landing__row landing__row--wrapCenter text--charcoal" >
+        <div class="landing__container--center landing__row--wrapCenter landing__row--reverse" style="max-width: 1500px; margin: 30px 0;">
+            <div class="landing__col-1-2--lg landing__col-1-1">
+                <picture class="landing__figImg">
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_CarbonSteelFirePit_Desktop.webp" type="image/webp">
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_CarbonSteelFirePit_Desktop.jpg" type="image/jpeg">
+                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_CarbonSteelFirePit_Desktop.webp" alt="A round carbon steel fire bowl with burning wood." class="landing__figImg landing__figImg--default lazy-image">
+                </picture>
+            </div>
+            <div class="landing__col-1-2--lg landing__col-1-1">
+                <h2 class="landing__header landing__header--2 upper l">
+                    Carbon Steel
+                </h2>
+                <p class="landing__p l">
+                    &bull; Exceptionally durable and low maintenance.
+                </p>
+                <p class="landing__p l">
+                    &bull; Great for both wood- and gas-burning fire pits.
+                </p>
+                <p class="landing__p l">
+                    &bull; Brands like Fire Pit Art, pictured, are handmade in the US and available in a variety of sizes and unique shapes. Inquire for custom options.
+                </p>
+                
+                <p class="landing__p l bg--gray bold" style="padding: 10px; margin: 20px 0; max-width: 640px;">
+                    
+                    Style tip: Many carbon steel fire pits feature an oxide patina that's virtually maintenance-free and will mature and darken over time.
+                    
+                </p>
+                <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_material:Steel" title="Shop Carbon Steel Fire Pits"  class="button button-primary--white button--left button--center--sm">
+                    Shop carbon steel fire pits
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <div class="landing__row landing__row--wrapCenter text--charcoal" >
+        <div class="landing__container--center landing__row--wrapCenter" style="max-width: 1500px; margin: 30px 0;">
+            <div class="landing__col-1-2--lg landing__col-1-1">
+                <picture class="landing__figImg">
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_CortenSteelFirePit_Desktop.webp" type="image/webp">
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_CortenSteelFirePit_Desktop.jpg" type="image/jpeg">
+                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_CortenSteelFirePit_Desktop.webp" alt="A pyramid shape corten steel fire pit in front of a woven chair." class="landing__figImg landing__figImg--default lazy-image">
+                </picture>
+            </div>
+            <div class="landing__col-1-2--lg landing__col-1-1">
+                <h2 class="landing__header landing__header--2 upper l">
+                    Corten Steel
+                </h2>
+                <p class="landing__p l">
+                    &bull; Often referred to as “weathering steel,” will begin to oxidize and take on a rustlike appearance when placed outside.
+                </p>
+                <p class="landing__p l">
+                    &bull; Resists corrosion and will maintain tensile strength.
+                </p>
+                <p class="landing__p l">
+                    &bull; Available in wood, natural gas, and liquid propane fuel types.
+                </p>
+                
+                <p class="landing__p l bg--gray bold" style="padding: 10px; margin: 20px 0; max-width: 640px;">
+                    
+                    Style tip: Full oxidation takes close to six months.
+                    
+                </p>
+                <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_material:Steel" title="Shop Corten Steel Fire Pits"  class="button button-primary--white button--left button--center--sm">
+                    Shop corten steel fire pits
+                </a>
+            </div>
+        </div>
+
+        <div class="landing__row landing__row--wrapCenter text--charcoal" >
+            <div class="landing__container--center landing__row--wrapCenter landing__row--reverse" style="max-width: 1500px; margin: 30px 0;">
+                <div class="landing__col-1-2--lg landing__col-1-1">
+                    <picture class="landing__figImg">
+                        <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_StainlessSteelFirePit_Desktop.webp" type="image/webp">
+                        <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_StainlessSteelFirePit_Desktop.jpg" type="image/jpeg">
+                            <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_StainlessSteelFirePit_Desktop.webp" alt="A round stainless steel fire pit in front of a sofa and chair." class="landing__figImg landing__figImg--default lazy-image">
+                    </picture>
+                </div>
+                <div class="landing__col-1-2--lg landing__col-1-1">
+                    <h2 class="landing__header landing__header--2 upper l">
+                        Stainless Steel
+                    </h2>
+                    <p class="landing__p l">
+                        &bull; Ideal for withstanding fire and weather conditions.
+                    </p>
+                    <p class="landing__p l">
+                        &bull; Typically found in a natural, brushed finish and a (newer) powder-coated finish.
+                    </p>
+                    <p class="landing__p l">
+                        &bull; Generally higher priced than other materials because of its high quality and durability.
+                    </p>
+                    
+                    <p class="landing__p l bg--gray bold" style="padding: 10px; margin: 20px 0; max-width: 640px;">
+                        
+                        Style tip: Stainless steel pits are typically sleek and contemporary, making them the preferred choice for a modern aesthetic.
+                        
+                    </p>
+                    <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_material:Stainless$2520Steel" title="Shop Stainless Steel Fire Pits"  class="button button-primary--white button--left button--center--sm">
+                        Shop stainless steel fire pits
+                    </a>
+                </div>            
+            </div>
+        </div>
+    </div>
+
+    <div class="landing__row landing__row--wrapCenter text--charcoal" >
+        <div class="landing__container--center landing__row--wrapCenter" style="max-width: 1500px; margin: 30px 0;">
+            <div class="landing__col-1-2--lg landing__col-1-1">
+                <picture class="landing__figImg">
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_Concrete_Desktop.webp" type="image/webp">
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_Concrete_Desktop.jpg" type="image/jpeg">
+                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_Concrete_Desktop.webp" alt="A large concrete fire table in front of a sofa where three women are sitting." class="landing__figImg landing__figImg--default lazy-image">
+                </picture>
+            </div>
+            <div class="landing__col-1-2--lg landing__col-1-1">
+                <h2 class="landing__header landing__header--2 upper l">
+                    Concrete
+                </h2>
+                <p class="landing__p l">
+                    &bull; Exceptionally durable in varying climates and do not chip, patina, or peel over time.
+                </p>
+                <p class="landing__p l">
+                    &bull; Available as fire bowls and fire tables.
+                </p>
+                <p class="landing__p l">
+                    &bull; Best suited for natural gas and liquid propane fuel systems.
+                </p>
+                <p class="landing__p l">
+                    &bull; Available in a wide range of sizes, shapes, and heights.
+                </p>
+                <p class="landing__p l bg--gray bold" style="padding: 10px; margin: 20px 0; max-width: 640px;">
+                    
+                    Style tip: Concrete fire pits tend to be heavy and are not typically placed on raised wooden decks.
+                    
+                </p>
+                <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_material:Concrete" title="Shop Concrete Fire Pits"  class="button button-primary--white button--left button--center--sm">
+                    Shop concrete fire pits
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <div class="landing__row landing__row--wrapCenter text--charcoal" >
+        <div class="landing__container--center landing__row--wrapCenter landing__row--reverse" style="max-width: 1500px; margin: 30px 0;">
+            <div class="landing__col-1-2--lg landing__col-1-1">
+                <picture class="landing__figImg">
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_Marine_Desktop.webp" type="image/webp">
+                    <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_Marine_Desktop.jpg" type="image/jpeg">
+                        <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_Marine_Desktop.webp" alt="A brown plastic fire table surrounded by some chairs in front of a pool." class="landing__figImg landing__figImg--default lazy-image">
+                </picture>
+            </div>
+            <div class="landing__col-1-2--lg landing__col-1-1">
+                <h2 class="landing__header landing__header--2 upper l">
+                    Marine Grade Polymer (MGP)
+                </h2>
+                <p class="landing__p l">
+                    &bull; Sturdy, easy to maintain, and withstand all kinds of weather.
+                </p>
+                <p class="landing__p l">
+                    &bull; Frequently have aluminium accents.
+                </p>
+                
+                <p class="landing__p l bg--gray bold" style="padding: 10px; margin: 20px 0; max-width: 640px;">
+                    
+                    Style tip: The polymer content allows MGP fire pits to be made in a variety of colors.
+                    
+                </p>
+                <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_material:MGP$252FAluminum" title="Shop MGP Fire Pits"  class="button button-primary--white button--left button--center--sm">
+                    Shop MGP fire pits
+                </a>
+            </div>
+        </div>
+
+        <div class="landing__row landing__row--wrapCenter text--charcoal" >
+            <div class="landing__container--center landing__row--wrapCenter" style="max-width: 1500px; margin: 30px 0;">
+                <div class="landing__col-1-2--lg landing__col-1-1">
+                    <picture class="landing__figImg">
+                        <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_NaturalStone_Desktop.webp" type="image/webp">
+                        <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_NaturalStone_Desktop.jpg" type="image/jpeg">
+                            <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_NaturalStone_Desktop.webp" alt="A rectangular stone fire table surrounded by some chairs." class="landing__figImg landing__figImg--default lazy-image">
+                    </picture>
+                </div>
+                <div class="landing__col-1-2--lg landing__col-1-1">
+                    <h2 class="landing__header landing__header--2 upper l">
+                        Natural Stone
+                    </h2>
+                    <p class="landing__p l">
+                        &bull; Commonly used for permanent installations and are not intended to be moved.
+                    </p>
+                    <p class="landing__p l">
+                        &bull; Ideal for both wood-burning and gas fuel systems.
+                    </p>
+                    <p class="landing__p l">
+                        &bull; Feature a naturally textured finish and are able to withstand any weather.
+                    </p>
+                    
+                    <p class="landing__p l bg--gray bold" style="padding: 10px; margin: 20px 0; max-width: 640px;">
+                        
+                        Style tip: R & R Living Fire Pits, pictured, feature handmade finishes in natural stone.
+                        
+                    </p>
+                    <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_material:Natural$2520Stone" title="Shop Natural Stone Fire Pits"  class="button button-primary--white button--left button--center--sm">
+                        Shop natural stone fire pits
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!--Color Footer-->
+    <div class="landing__row landing__row--wrapCenter" style="background-color: #4D5060; padding: 130px 0;">
+        <div class="landing__container--center landing__row--wrapCenter" style="max-width: 1676px; padding: 0 20px;">
+            <table style="width: 100%; margin: auto; border-collapse: collapse; border: none;">
+                <tr>
+                    <td style="border: none; max-width: 600px; width: 36%;">
+                        <hr style="border: 1px solid #ccc; height: .01rem;">
+                    </td>
+                    <td class="no-pad" style="border: none; max-width: 476px; width: 28%;">
+                        <h2 class="landing__header landing__header--1 landing__header--space text--white serif no-margin">FIRE PIT SHAPE</h2>
+                    </td>
+                    <td style="border: none; max-width: 600px; width: 36%;">
+                        <hr style="border: 1px solid #ccc; height: .01rem;">
+                    </td>
+                </tr>
+            </table>
+            
+            <div class="landing__col-1-1">
+                <div class="landing__container--center landing__row--wrapCenter" style="max-width: 1020px; margin: auto;">
+                    <p class="landing__p c text--white" style="padding: 56px 0 0;">
+                        Round, rectangular, and square shapes are most popular in fire pits, but oval, hexagonal, octagonal and pyramid shapes are also available. Select a shape and size that works best for your space—based on form and function.
+                    </p>
+                </div>
+                <div class="landing__row landing__row--wrapCenter" style="margin: 10px 0 85px">
+                    <div class="landing__col-1-3--lg landing__col-1-2" style="margin: 35px 0 0;">
+                        <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_shape:Square" title="Shop Square Fire Pits">
+                            <picture class="landing__figImg">
+                                <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_SquareFirePit_Desktop.webp" type="image/webp">
+                                <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_SquareFirePit_Desktop.jpg" type="image/jpeg">
+                                    <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_SquareFirePit_Desktop.webp" alt="A square fire pit in front of two chairs." class="landing__figImg landing__figImg--default lazy-image">
+                            </picture>
+                            <div class="button button--long button-primary--transparent margin-top">Shop square fire pits</div>
+                        </a>
+                    </div>
+                    <div class="landing__col-1-3--lg landing__col-1-2" style="margin: 35px 0 0;">
+                        <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_shape:Rectangular" title="Shop Rectangular Fire Pits">
+                            <picture class="landing__figImg">
+                                <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_RectangleFirePit_Desktop.webp" type="image/webp">
+                                <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_RectangleFirePit_Desktop.jpg" type="image/jpeg">
+                                    <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_RectangleFirePit_Desktop.webp" alt="A rectangular fire pit in between a sofa and two chairs." class="landing__figImg landing__figImg--default lazy-image">
+                            </picture>
+                            <div class="button button--long button-primary--transparent margin-top">Shop rectangular fire pits</div>
+                        </a>
+                    </div>
+                    <div class="landing__col-1-3--lg landing__col-1-2" style="margin: 35px 0 0;">
+                        <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_shape:Pyramid" title="Shop Pyramid Fire Pits">
+                            <picture class="landing__figImg">
+                                <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_PyramidFirePit_Desktop.webp" type="image/webp">
+                                <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_PyramidFirePit_Desktop.jpg" type="image/jpeg">
+                                    <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_PyramidFirePit_Desktop.webp" alt="A pyramid fire pit in front of a loveseat." class="landing__figImg landing__figImg--default lazy-image">
+                            </picture>
+                            <div class="button button--long button-primary--transparent margin-top">Shop pyramid fire pits</div>
+                        </a>
+                    </div>
+                    <div class="landing__col-1-3--lg landing__col-1-2" style="margin: 35px 0 0;">
+                        <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_shape:Round" title="Shop Round Fire Pits">
+                            <picture class="landing__figImg">
+                                <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_RoundFirePit_Desktop.webp" type="image/webp">
+                                <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_RoundFirePit_Desktop.jpg" type="image/jpeg">
+                                    <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_RoundFirePit_Desktop.webp" alt="A round fire pit on a deck in front of a sofa." class="landing__figImg landing__figImg--default lazy-image">
+                            </picture>
+                            <div class="button button--long button-primary--transparent margin-top">Shop round fire pits</div>
+                        </a>
+                    </div>
+                    <div class="landing__col-1-3--lg landing__col-1-2" style="margin: 35px 0 0;">
+                        <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_shape:Oval" title="Shop Oval Fire Pits">
+                            <picture class="landing__figImg">
+                                <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_OvalFirePit_Desktop.webp" type="image/webp">
+                                <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_OvalFirePit_Desktop.jpg" type="image/jpeg">
+                                    <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_OvalFirePit_Desktop.webp" alt="A oval shape fire pit in front of a sectional." class="landing__figImg landing__figImg--default lazy-image">
+                            </picture>
+                            <div class="button button--long button-primary--transparent margin-top">Shop oval fire pits</div>
+                        </a>
+                    </div>
+                    <div class="landing__col-1-3--lg landing__col-1-2" style="margin: 35px 0 0;">
+                        <a href="https://authenteak.com/outdoor-heating/fire-pits-fire-tables/shop-all-fire-pits-fire-tables/#/filter:custom_shape:Hexagonal/filter:custom_shape:Octagon" title="Shop Geometric Fire Pits">
+                            <picture class="landing__figImg">
+                                <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_GeometricFirePit_Desktop.webp" type="image/webp">
+                                <source srcset="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/JPG/WS00071_051121_FirePitBuyingGuide_GeometricFirePit_Desktop.jpg" type="image/jpeg">
+                                    <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/EM00071_051121_FirePitBuyingGuide_Images/WEBP/WS00071_051121_FirePitBuyingGuide_GeometricFirePit_Desktop.webp" alt="An octagonal shape fire pit on a patio." class="landing__figImg landing__figImg--default lazy-image">
+                            </picture>
+                            <div class="button button--long button-primary--transparent margin-top">Shop geometric fire pits</div>
+                        </a>
                     </div>
                 </div>
-            </div> -->
-        </div>
-    </div>
-    
-    <div class="landing__row landing__row--wrapCenter margin-top">
-        <div class="landing__container landing__container--center margin-top">
-            <div class="landing__col-1-1 margin-top">
-                <h2 class="landing__header landing__header--2 c no-margin">
-                    FEATURED CLIENTS
-                </h2>
-            </div>
-            <div class="landing__col-1-3 landing__col--flexCenter">
-               <p class="landing__p l">
-                Amanyara Resort, Turks & Caicos<br>
-                Ansley Golf Club<br>
-                Arnette’s Chop Shop<br>
-                Atlanta Athletic Club<br>
-                Atlanta Botanic Garden<br>
-                Atlanta Hawks Training Facility<br>
-                Auberge Park City<br>
-                Avana Lenox<br>
-                Barley Garden Pinewood<br>
-                Bold Monk Brewing Co.<br>
-                BRASH Coffee<br>
-                Cider Haus<br>
-                City of Conyers Complex Center<br>
-                Colonial Williamsburg<br>
-                Comcast at The Battery<br>
-                Doc Ford’s<br>
-                Emory University<br>
-                Equinox Gym
-               </p>
-            </div>
-            <div class="landing__col-1-3 landing__col--flexCenter">
-                <p class="landing__p l">
-                    Franklin Hills Country Club<br>
-                    Halcyon<br>
-                    Hamilton Princess<br>
-                    Hedgewood Homes<br>
-                    Jeni's Splendid Ice Creams<br>
-                    Kiawah Island Club<br>
-                    Lake Toxaway Country Club<br>
-                    Longbow Golf Club<br>
-                    Madison Yards<br>
-                    Mariner Sands Country Club<br>
-                    Medina Golf and Country Club<br>
-                    Mercedes Benz Headquarters<br>
-                    Montage Palmetto Bluff<br>
-                    Morelli's Ice Cream<br>
-                    Mosaic Hotel Group<br>
-                    Mr. C Hotel Miami<br>
-                    Mr. C Hotel New York City<br>
-                    Northwestern University
-                </p>
-            </div>
-            <div class="landing__col-1-3 landing__col--flexCenter">
-                <p class="landing__p l">
-                    Ocean Reef at Stirrup Cay<br>
-                    Oglethorpe University<br>
-                    Old Edwards Inn<br>
-                    Renaissance Hotel – Toledo<br>
-                    Reynolds Lake Oconee<br>
-                    Scapes Group<br>
-                    Scofflaw Brewing Co.<br>
-                    Sweetwater Brewery<br>
-                    T3 Building<br>
-                    Temple Sinai<br>
-                    The Cotton House, Mustique<br>
-                    The Loren Hotel, Bermuda<br>
-                    The Lovett School<br>
-                    The Plaza Midtown<br>
-                    The University of the South<br>
-                    University of North Georgia<br>
-                    Uptown Kenwood<br>
-                    Western Carolina University
-                </p>
+                
+                
             </div>
         </div>
     </div>
 
-    <div class="landing__row landing__row--wrapCenter bg--grey margin-top-lg margin-bottom-lg">
-        <div class="landing__container landing__container--center landing__row--wrapCenter margin-top">
-            <div class="landing__col-2-4--xl landing__col-1-1">
-                <a class="upper" style="color: #2E303B; font-size: 32px; letter-spacing: 3.2px; line-height: 37px;" >
-                    Become An AuthenTEAK <span style="color: #6EA349;">PRO</span>
-                </a>
-            </div>
-            <div class="landing__col-1-4--xl landing__col-1-3--lg landing__col-1-2">
-                <a href="" class="button" style="white-space: nowrap; color: #fff; font-size: 20px;">Apply to our trade program</a>
-            </div>
-            <div class="landing__col-1-4--xl landing__col-1-3--lg landing__col-1-2">
-                <a href="" class="button" style="white-space: nowrap; background-color: #F0F0F0; color: #2E303B; border: 1px solid #2E303B; font-size: 20px;">&nbsp; &nbsp; Get a hospitality quote &nbsp; &nbsp;</a>
-            </div>
-        </div>
-    </div>
-
-    <div class="landing__row landing__row--wrapCenter">
-        <div class="landing__container landing__container--center landing__row--wrapCenter">
-            <div class="landing__col-1-1">
-                <a href="https://www.instagram.com/authenteakoutdoorliving/">
-                    <picture class="landing__figImg">
-                        <source media="(min-width: 700px)" srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_SocialSpotlight.webp" type="image/webp">
-                        <source media="(min-width: 700px)" srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/JPG/WS0002_SocialSpotlight.jpg" type="image/jpeg">
-                        <source media="(max-width: 669px)" srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_SocialSpotlight_Mobile.webp" type="image/webp">
-                        <source media="(max-width: 669px)" srcset="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/JPG/WS0002_SocialSpotlight_Mobile.jpg" type="image/jpeg">
-                            <img data-src="https://authenteak.s3.us-east-2.amazonaws.com/WS00002_031821_TradePage_images/WEBP/WS0002_SocialSpotlight.webp" alt="" type="image/webp" class="landing__figImg landing__figImg--default lazy-image" >
-                    </picture>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="landing__row landing__row--wrapCenter">
-        <div class="landing__container landing__container--center">
-            <div class="landing__col-1-1">
-                <h2 class="landing__header landing__header--2 l" style="letter-spacing: 3.2px; line-height: 37px;">
-                    WE'RE EVOLVING
-                </h2>
-                <p class="landing__p l" style="font-size: 24px; letter-spacing: 1.2px; line-height: 28px;">
-                    The AuthenTEAK Trade Program is now <strong>AuthenTEAK PRO</strong>.<br>
-                    Trade member accounts have been upgraded with a host of new features. We’ve taken our trade business online where you will now be able to place orders utilizing your trade discount 24/7. As a highly valued trade program member, your benefits include exclusive trade pricing, no ancillary fees and dedicated project support from quotation to completion.
-                </p>
-            </div>
-        </div>
-    </div>
 </div>
 
 {{/partial}}


### PR DESCRIPTION
buttons.scss -
Added a float left and float right for buttons.
Added a way to center buttons for mobile if the buttons have a float.
Changed the -primary--white styling with different colors.
Changed the -primary--transparent styling with different colors.
Changed the --long styling to have a taller button.

generic.scss:
Removed the --bg-img class.
Added hp-bannerImg-1 and hp-bannerImg-2 in order to accommodate two banner background images in the homepage.
Added a hestan-bannerImg and alfresco-bannerImg to accommodate a background banner on each of those pages.
Added a topStroke class that adds a background gradient of white and light blue for the image background for the Brand pages.
Added a col-spacing class to accommodate the space where the CSS carousel for the trade page goes since the carousel is absolute.
Changed the opacity of the carousel images when they are in the background on mobile from .3 to .1 so that the caption of the front image is more readable.

In order to truncate the website at 1920px so that the page designs did not break on higher resolutions, I made the following changes to default.scss and landing.scss
default.scss:
Added a display flex, flex-direction of column, and align-items of center
landing.scss:
Added a max-width: 1920px and a width of 100%.